### PR TITLE
Current user / session refactor

### DIFF
--- a/app/app/(dashboard)/admin/debug/page.tsx
+++ b/app/app/(dashboard)/admin/debug/page.tsx
@@ -25,6 +25,7 @@ const StripeDebug = async () => {
         <Link href="/settings/payment">Stripe Connect</Link> <br/>
         <Link href="/subscriptions">Your active subscriptions</Link> <br/>
         <Link href="/admin/debug/onboarding">Onboarding State</Link> <br/>
+        <Link href="/admin/debug/session">Session Viewer</Link> <br/>
         <RoleSwitcher />
       </div>
     </div>

--- a/app/app/(dashboard)/admin/debug/session/page.tsx
+++ b/app/app/(dashboard)/admin/debug/session/page.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import PageHeading from "@/components/common/page-heading";
+import { Button, Card } from "@tremor/react";
+import { useSession } from "next-auth/react";
+
+export default function Page() {
+  const { data: session, status, update } = useSession();
+
+  if (status === "authenticated") {
+    return (
+      <Card>
+        <PageHeading>Session Debug Tool</PageHeading>
+        <br/>
+        <pre>{JSON.stringify(session, null, 2)}</pre>
+        <br/>
+        <Button onClick={() => update()}>Refresh session data</Button>
+      </Card>
+    )
+  }
+
+  return <a href="/api/auth/signin">Sign in</a>;
+}

--- a/app/app/(dashboard)/customers/page.tsx
+++ b/app/app/(dashboard)/customers/page.tsx
@@ -2,7 +2,6 @@ import SubscriptionService, {
   SubscriptionWithUser,
 } from "@/app/services/SubscriptionService";
 import LinkButton from "@/components/common/link-button";
-import UserService from "@/app/services/UserService";
 import DashboardCard from "@/components/common/dashboard-card";
 import PageHeading from "@/components/common/page-heading";
 import {
@@ -16,13 +15,14 @@ import {
   TableRow,
   Text,
 } from "@tremor/react";
+import SessionService from "@/app/services/SessionService";
 
 export default async function CustomersList({
   params,
 }: {
   params: { id: string };
 }) {
-  const currentUserId = await UserService.getCurrentUserId();
+  const currentUserId = await SessionService.getCurrentUserId();
   const subscriptions: SubscriptionWithUser[] =
     await SubscriptionService.subscribedToUser(currentUserId!);
 

--- a/app/app/(dashboard)/layout.tsx
+++ b/app/app/(dashboard)/layout.tsx
@@ -1,5 +1,4 @@
 import { ReactNode, Suspense } from "react";
-import { getSession } from "@/lib/auth";
 import Profile from "@/components/profile";
 import Nav from "@/components/nav";
 import { redirect } from "next/navigation";
@@ -7,20 +6,23 @@ import { getOnlySiteFromUserId } from "@/app/services/SiteService";
 import { Flex } from "@tremor/react";
 import OnboardingGuide from "@/components/onboarding/onboarding-guide";
 import { DasboardProvider } from "@/components/dashboard/dashboard-context";
+import SessionService from "@/app/services/SessionService";
 
 
 export default async function DashboardLayout({ children }: { children: ReactNode }) {
-  const session = await getSession();
+  const session = await SessionService.getSession();
+  const { id: userId, roleId } = session?.user || {};
 
-  if (!session) {
+  if (!userId) {
     redirect("/login");
   }
-  const site = await getOnlySiteFromUserId(session.user.id);
+
+  const site = await getOnlySiteFromUserId(userId);
 
   return (
     <DasboardProvider siteId={site?.id ?? null}>
       <div>
-        <Nav siteId={site?.id ?? null} roleId={session.user?.roleId || 'anonymous'}>
+        <Nav siteId={site?.id ?? null} roleId={roleId || 'anonymous'}>
           <Suspense fallback={<div>Loading...</div>}>
             <Profile />
           </Suspense>

--- a/app/app/(dashboard)/site/[id]/analytics/page.tsx
+++ b/app/app/(dashboard)/site/[id]/analytics/page.tsx
@@ -1,16 +1,17 @@
-import { getSession } from "@/lib/auth";
 import prisma from "@/lib/prisma";
 import { notFound, redirect } from "next/navigation";
 import AnalyticsMockup from "@/components/analytics";
 import DomainService from "@/app/services/domain-service";
+import SessionService from "@/app/services/SessionService";
 
 export default async function SiteAnalytics({
   params,
 }: {
   params: { id: string };
 }) {
-  const session = await getSession();
-  if (!session) {
+  const userId = await SessionService.getCurrentUserId();
+  
+  if (!userId) {
     redirect("/login");
   }
   const data = await prisma.site.findUnique({
@@ -18,7 +19,7 @@ export default async function SiteAnalytics({
       id: decodeURIComponent(params.id),
     },
   });
-  if (!data || data.userId !== session.user.id) {
+  if (!data || data.userId !== userId) {
     notFound();
   }
 

--- a/app/app/(dashboard)/tiers/page.tsx
+++ b/app/app/(dashboard)/tiers/page.tsx
@@ -3,11 +3,11 @@ import PrimaryButton from '@/components/common/link-button';
 import TierService, { TierWithFeatures } from '@/app/services/TierService';
 import { Grid, Badge } from '@tremor/react';
 
-import UserService from '@/app/services/UserService';
 import TierCard from '@/components/tiers/tier-card';
+import SessionService from '@/app/services/SessionService';
 
 export default async function Tiers() {
-  const currentUserId = await UserService.getCurrentUserId();
+  const currentUserId = await SessionService.getCurrentUserId();
   if (!currentUserId) return <>You must log in</>;
 
   const tiers: TierWithFeatures[] = await TierService.findByUserIdWithFeatures(currentUserId);

--- a/app/models/Session.tsx
+++ b/app/models/Session.tsx
@@ -1,0 +1,37 @@
+import { User } from "@prisma/client";
+
+export type SessionUser = {
+  id?: string;
+  name?: string;
+  username?: string;
+  email?: string;
+  image?: string;
+  onboarding?: string;
+  roleId: string;
+  stripeCustomerId?: string;
+  stripePaymentMethodId?: string;
+  stripeProductId?: string;
+  stripeAccountId?: string;
+};
+
+export type Session = {
+  user: SessionUser;
+  expires: string;
+} | null;
+
+export const createSessionUser = (user: User): SessionUser => {
+  return {
+    name: user.name || undefined,
+    username: user.username || user.gh_username || undefined,
+    email: user.email || undefined,
+    roleId: user.roleId || 'anonymous',
+    onboarding: user.onboarding || undefined,
+    image: user.image || undefined,
+    stripeCustomerId: user.stripeCustomerId || undefined,
+    stripePaymentMethodId: user.stripePaymentMethodId || undefined,
+    stripeProductId: user.stripeProductId || undefined,
+    stripeAccountId: user.stripeAccountId || undefined,
+  }
+}
+
+export default Session;

--- a/app/services/PageService.tsx
+++ b/app/services/PageService.tsx
@@ -1,17 +1,13 @@
 "use server";
 
 import prisma from "@/lib/prisma";
-import { Page, Site } from "@prisma/client";
+import { Page } from "@prisma/client";
 import { getSession } from "@/lib/auth";
 import SiteService from "./SiteService";
 import { newPageTemplate} from "@/lib/constants/site-template";
+import SessionService from "./SessionService";
 
 class PageService {
-  static async getCurrentUserId() {
-    const session = await getSession();
-    return session?.user.id;
-  }
-
   static getSubdomain(domain: string) {
     return domain.endsWith(`.${process.env.NEXT_PUBLIC_ROOT_DOMAIN}`)
     ? domain.replace(`.${process.env.NEXT_PUBLIC_ROOT_DOMAIN}`, "")
@@ -91,7 +87,7 @@ class PageService {
   
   static async findPage(subdomain: string, slug: string) {
 
-    const currentUserId = await PageService.getCurrentUserId();
+    const currentUserId = await SessionService.getCurrentUserId();
   
     const site = await prisma.site.findUnique({
       where: { 
@@ -120,7 +116,7 @@ class PageService {
   };
 
   static async setHomepage(siteId: string, id: string) {
-    const userId = await PageService.getCurrentUserId();
+    const userId = await SessionService.getCurrentUserId();
     return await prisma.site.update({
       where: {
         id: siteId,
@@ -133,7 +129,7 @@ class PageService {
   };
 
   static async deletePage(id: string) {
-    const userId = await PageService.getCurrentUserId();
+    const userId = await SessionService.getCurrentUserId();
 
     // First, retrieve the page along with the related site's homepageId
     const page = await prisma.page.findUnique({

--- a/app/services/ProductService.tsx
+++ b/app/services/ProductService.tsx
@@ -1,15 +1,14 @@
 "use server";
 
 import prisma from "@/lib/prisma";
-import { getSession } from "@/lib/auth";
 import Product from "@/app/models/Product";
 import StripeService from "./StripeService";
 import UserService from "./UserService";
+import SessionService from "./SessionService";
 
 class ProductService {
   static async getCurrentUserId() {
-    const session = await getSession();
-    return session?.user.id;
+    return SessionService.getCurrentUserId();
   }
 
   static async findProduct(userId: string): Promise<Product | null> {

--- a/app/services/RepoService.tsx
+++ b/app/services/RepoService.tsx
@@ -1,6 +1,5 @@
 "use server";
 import SessionService from "./SessionService";
-import UserService from "./UserService";
 
 import prisma from "@/lib/prisma";
 
@@ -79,7 +78,7 @@ class RepoService {
 
     static async getRepos() {
         // get repos of a given userId from the database
-        const userId = await UserService.getCurrentUserId();
+        const userId = await SessionService.getCurrentUserId();
 
         if (!userId) {
             throw new Error('No user found.');
@@ -101,7 +100,7 @@ class RepoService {
       try {
         const accessToken = await SessionService.getAccessToken();
 
-        const userId = await UserService.getCurrentUserId();
+        const userId = await SessionService.getCurrentUserId();
 
         if (!accessToken) {
             throw new Error('No access token found.');

--- a/app/services/SessionService.tsx
+++ b/app/services/SessionService.tsx
@@ -1,12 +1,31 @@
 import { getSession } from '@/lib/auth';
 import prisma from "@/lib/prisma";
+import { SessionUser } from '../models/Session';
 
 class SessionService {
+  static async getSession() {
+    return getSession();
+  }
+
+  static async getCurrentUserId() {
+    const session = await getSession();
+    return session?.user!.id;
+  }
+
+  static async getSessionUser(): Promise<SessionUser | undefined> {
+    const session = await getSession();
+    return session?.user;
+  }
+
+  static async signedIn(){
+    const session = await getSession();
+    return !!session?.user!.id;
+  }
 
   // return a refreshed acccess token of github
   static async getAccessToken() : Promise<string | null> {
     const session = await getSession();
-    const userId = session?.user.id;
+    const userId = session?.user!.id;
 
     try {
       // Retrieve the current refresh token from the database
@@ -65,4 +84,4 @@ class SessionService {
 }
 
 export default SessionService;
-export const { getAccessToken } = SessionService;
+export const { getAccessToken, getCurrentUserId } = SessionService;

--- a/app/services/SiteService.tsx
+++ b/app/services/SiteService.tsx
@@ -9,7 +9,7 @@ import { customAlphabet } from "nanoid";
 import fs from 'fs';
 import yaml from 'js-yaml';
 import { put } from "@vercel/blob";
-import UserService, { getCurrentUserId } from './UserService';
+import SessionService from './SessionService';
 
 const nanoid = customAlphabet(
   "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz",
@@ -33,7 +33,7 @@ const reservedSubdomains = loadReservedSubdomains() as string[];
 class SiteService {
 
     static async getCurrentSite() {
-        const userId = await getCurrentUserId();
+        const userId = await SessionService.getCurrentUserId();
 
         if (!userId) {
             throw new Error('No user found.');
@@ -43,7 +43,7 @@ class SiteService {
     }
 
     static async getSiteAndPages(id: string) {
-        const userId = await UserService.getCurrentUserId();
+        const userId = await SessionService.getCurrentUserId();
         const site = await prisma.site.findUnique({
             where: {
                 id: decodeURIComponent(id),

--- a/app/services/SubscriptionService.tsx
+++ b/app/services/SubscriptionService.tsx
@@ -7,6 +7,7 @@ import UserService from "./UserService";
 import { Subscription, Tier, User } from "@prisma/client";
 import TierService from "./TierService";
 import EmailService from "./EmailService";
+import SessionService from "./SessionService";
 
 export type SubscriptionWithUser = Subscription & { user: User, tier?: Tier};
 
@@ -24,7 +25,7 @@ class SubscriptionService {
   }
 
   static async findSubscriptionByTierId({ tierId }: { tierId: string; }): Promise<Subscription | null> {
-    const userId = await UserService.getCurrentUserId();
+    const userId = await SessionService.getCurrentUserId();
     
     if(!userId) return null;
 
@@ -41,7 +42,7 @@ class SubscriptionService {
   }
 
   static async findSubscriptions(): Promise<Subscription[]> {
-    const userId = await UserService.getCurrentUserId();
+    const userId = await SessionService.getCurrentUserId();
     if(!userId) return [];
 
     const subscriptions = await prisma.subscription.findMany({

--- a/app/services/TierService.tsx
+++ b/app/services/TierService.tsx
@@ -1,20 +1,18 @@
 "use server";
 
 import prisma from "@/lib/prisma";
-import { getSession } from "@/lib/auth";
 import Tier, { newTier } from "@/app/models/Tier";
 import StripeService from "./StripeService";
 import UserService from "./UserService";
 import { Feature } from "@prisma/client";
 import ProductService from "./ProductService";
-import FeatureService from "./feature-service";
+import SessionService from "./SessionService";
 
 export type TierWithFeatures = Tier & { features?: Feature[] };
 
 class TierService {
   static async createStripePrice(tier: Tier) {
-    const session = await getSession();
-    const userId = session?.user.id;
+    const userId = await SessionService.getCurrentUserId();
 
     if(!userId) {
       throw new Error('User not authenticated');
@@ -28,7 +26,7 @@ class TierService {
 
     if(!currentUser.stripeProductId) {
       ProductService.createProduct(currentUser.id);
-      currentUser = await UserService.findUser(session.user.id);
+      currentUser = await UserService.findUser(userId);
       if(!currentUser?.stripeProductId) {
         throw new Error('Tried to attach a stripe product id to user, but failed.');
       }
@@ -113,7 +111,7 @@ class TierService {
 
   static async updateTier(id: string, tierData: Partial<Tier>) {
     // Ensure the current user is the owner of the tier or has permissions to update it
-    const userId = await UserService.getCurrentUserId();
+    const userId = await SessionService.getCurrentUserId();
 
     if (!userId) {
       throw new Error("User not authenticated");
@@ -272,15 +270,16 @@ class TierService {
 
   // this pulls all tiers for the admin to manage
   static async getTiersForAdmin() {
-    const session = await getSession();
-    if (!session?.user.id) {
+    const userId = await SessionService.getCurrentUserId();
+
+    if (!userId) {
       return {
         error: "Not authenticated",
       };
     }
     return prisma.tier.findMany({
       where: {
-        userId: session.user.id
+        userId
       },
       select: {
         id: true,
@@ -308,8 +307,9 @@ class TierService {
   }
 
   static async getCustomersOfUserTiers() {
-    const session = await getSession();
-    if (!session?.user.id) {
+    const userId = await SessionService.getCurrentUserId();
+
+    if (!userId) {
       throw new Error("User not authenticated");
     }
   
@@ -319,7 +319,7 @@ class TierService {
         subscriptions: {
           some: {
             tier: {
-              userId: session.user.id,
+              userId
             },
           },
         },
@@ -331,7 +331,7 @@ class TierService {
         subscriptions: {
           where: {
             tier: {
-              userId: session.user.id,
+              userId
             },
           },
           select: {
@@ -352,8 +352,8 @@ class TierService {
   }
   
   static async getLatestCustomers(numberOfRecords?: number, daysAgo?: number) {
-    const session = await getSession();
-    if (!session?.user.id) {
+    const userId = await SessionService.getCurrentUserId();
+    if (!userId) {
       throw new Error("User not authenticated");
     }
   
@@ -373,7 +373,7 @@ class TierService {
             subscriptions: {
               some: {
                 tier: {
-                  userId: session.user.id,
+                  userId
                 },
                 createdAt: dateFilter ? { gte: dateFilter } : undefined,
               },
@@ -388,7 +388,7 @@ class TierService {
         subscriptions: {
           where: {
             tier: {
-              userId: session.user.id,
+              userId
             },
             createdAt: dateFilter ? { gte: dateFilter } : undefined,
           },
@@ -411,13 +411,13 @@ class TierService {
   }
 
   static async getTiersForMatrix(tierId?: string, newTier?: Tier): Promise<TierWithFeatures[]> {
-    const currentUser = await UserService.findCurrentUser();
+    const currentUserId = await SessionService.getCurrentUserId();
 
-    if (!currentUser) {
+    if (!currentUserId) {
       throw new Error("Not logged in");
     }
 
-    let allTiers: TierWithFeatures[] = await TierService.findByUserIdWithFeatures(currentUser.id);
+    let allTiers: TierWithFeatures[] = await TierService.findByUserIdWithFeatures(currentUserId);
 
     allTiers = allTiers.sort((a, b) => {
       if(tierId){

--- a/app/services/onboarding/OnboardingService.tsx
+++ b/app/services/onboarding/OnboardingService.tsx
@@ -3,7 +3,7 @@
 // like writing to db schema etc
 
 import prisma from "@/lib/prisma";
-import {getCurrentUserId} from "../UserService";
+import {getCurrentUserId} from "../SessionService";
 import type { OnboardingStepsType } from "./onboarding-steps";
 import { onboardingSteps } from "./onboarding-steps";
 

--- a/app/services/registration-service.tsx
+++ b/app/services/registration-service.tsx
@@ -29,9 +29,6 @@ class RegistrationService {
 
   
   static async registerAndSignInCustomer(userAttributes: Partial<User> ) { 
-    // FIXME
-    // return findCurrentUser();
-
     const res = await signIn("email", {
       redirect: false,
       email: userAttributes.email

--- a/components/common/TierSubscribeButton.tsx
+++ b/components/common/TierSubscribeButton.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { onClickSubscribe } from '@/app/services/StripeService';
-import { getCurrentUserId } from '@/app/services/UserService';
+import { getCurrentUserId } from '@/app/services/SessionService';
 import React, { useState } from 'react';
 
 const TierSubscribeButton = ({ tierId }: { tierId: string }) => {

--- a/components/dashboard/latest-customer-list.tsx
+++ b/components/dashboard/latest-customer-list.tsx
@@ -15,12 +15,12 @@ import {
 import SubscriptionService, {
   SubscriptionWithUser,
 } from "@/app/services/SubscriptionService";
-import UserService from "@/app/services/UserService";
 import DashboardCard from "@/components/common/dashboard-card";
 import TierService from "@/app/services/TierService";
 import PrimaryLinkButton from "../common/link-button";
 import Link from "next/link";
 import LinkButton from "../common/link-button";
+import SessionService from "@/app/services/SessionService";
 
 export default async function LatestCustomersList(props: { numRecords?: number, previewMode?: boolean }) {
 
@@ -33,7 +33,7 @@ export default async function LatestCustomersList(props: { numRecords?: number, 
   // Number of days to look back for new customers
   const daysAgo = 30;
 
-  const currentUserId = await UserService.getCurrentUserId();
+  const currentUserId = await SessionService.getCurrentUserId();
   const subscriptions: SubscriptionWithUser[] =
     await SubscriptionService.subscribedToUser(currentUserId!);
 

--- a/components/profile.tsx
+++ b/components/profile.tsx
@@ -3,14 +3,12 @@ import { redirect } from "next/navigation";
 import Link from "next/link";
 import Image from "next/image";
 import LogoutButton from "./logout-button";
-import { Flex, Text } from "@tremor/react";
 
 export default async function Profile() {
   const session = await getSession();
   if (!session?.user) {
     redirect("/login");
   }
-
 
   return (
     <>      

--- a/components/site/insertables/subscriptions/subscriptions-server.tsx
+++ b/components/site/insertables/subscriptions/subscriptions-server.tsx
@@ -1,21 +1,28 @@
-import { getSubscriptions } from '@/lib/tiers/fetchers';
-import Subscriptions from './subscriptions';
-import { getSession } from "@/lib/auth";
+import { getSubscriptions } from "@/lib/tiers/fetchers";
+import Subscriptions from "./subscriptions";
 import { Title } from "@tremor/react";
+import SessionService from "@/app/services/SessionService";
 
 // This is the component that will render at the frontend of the site, facing the customer
-export async function SubscriptionsServer({ site, page, ...props }: { site: any, page: any, props: any }) {
-    // a user should be logged in to view his/her subscriptions
-    const session = await getSession();
-    if (!session?.user.id) {
-        return (
-            <Title>You need to be logged in to view your subscriptions</Title>
-        )
-    }
+export async function SubscriptionsServer({
+  site,
+  page,
+  ...props
+}: {
+  site: any;
+  page: any;
+  props: any;
+}) {
+  // a user should be logged in to view his/her subscriptions
+  const userId = await SessionService.getCurrentUserId();
 
-    const subs = site?.userId ? await getSubscriptions(site.userId) as any[] : [];
+  if (!userId) {
+    return <Title>You need to be logged in to view your subscriptions</Title>;
+  }
 
-    return (
-        <Subscriptions subscriptions={subs} />
-    )
+  const subs = site?.userId
+    ? ((await getSubscriptions(site.userId)) as any[])
+    : [];
+
+  return <Subscriptions subscriptions={subs} />;
 }

--- a/components/user/role-switcher.tsx
+++ b/components/user/role-switcher.tsx
@@ -3,7 +3,6 @@ import { User } from "@prisma/client";
 import { useSession } from "next-auth/react"
 import { useCallback } from "react";
 import { useRouter } from 'next/navigation'
-import { Select } from "@tremor/react";
 
 export default function RoleSwitcher() {
     const { data: session, status, update } = useSession()
@@ -17,6 +16,7 @@ export default function RoleSwitcher() {
             }, 0)
         });
     }, [update, router])
+
     return (
         <>
         { user ?


### PR DESCRIPTION
* UserService.getCurrentUser() is now the canonical way to get the current user record
* SessionService.getSessionId / getSessionUser now return front-end consumable id and Partial<User>
* /admin/debug/session/ now lets you view and refresh your session
* updated auth.ts to handle session update correctly
* prevented non-admin users from role-switching
* you can now refresh sessions using the hook:

  import { useSession } from "next-auth/react";
  const { update } = useSession();