### PR TITLE
Call radar setup endpoint rather than lookup when connecting repos

### DIFF
--- a/app/services/LeadsService.tsx
+++ b/app/services/LeadsService.tsx
@@ -144,6 +144,20 @@ class LeadsService {
         }
     }
 
+    static async setup(repoUrl: string) {
+        try {
+            const response = await fetch(`${radarAPIEndpoint}repositories/setup?url=${repoUrl}`, { headers: LeadsService.commonHeaders });
+            return {
+                data: await response.json()
+            }
+        } catch (error: any) {
+            return {
+                error: 'Failed to setup repository'
+            }
+        }
+    }
+
+
     static async getDependentOwners(radarId: number, page: number, perPage: number, filters: FiltersState) {
         
         let url = `${radarAPIEndpoint}repositories/${radarId}/dependent_owners?per_page=${perPage}&page=${page}`;

--- a/app/services/RepoService.tsx
+++ b/app/services/RepoService.tsx
@@ -325,14 +325,14 @@ class RepoService {
 
     let radarId = null;
     try {
-      const repoLookupResult = await LeadsService.lookup(repoDetails.html_url);
-      radarId = repoLookupResult.data.id;
+      const repoSetupResult = await LeadsService.setup(repoDetails.html_url);
+      radarId = repoSetupResult.data.id;
     } catch (error) {
-      console.error('Failed to lookup repository:', error);
+      console.error('Failed to setup repository:', error);
     }
 
     if (!radarId) {
-      throw new Error('Failed to lookup repository.');
+      throw new Error('Failed to setup repository.');
     }
 
     // Insert the repo information into the database


### PR DESCRIPTION
As mentioning in https://github.com/git-wallet/gitwallet-web/issues/291

Calling setup, rather than lookup, will trigger extra data to be loaded for connected repos that isnt't otherwise used for looking up leads.