### PR TITLE
Bug Fix: Unauthenticated user is redirected to an auth-protected page after contact-us form is filled

### DIFF
--- a/app/app/(payments)/checkout/[id]/page.tsx
+++ b/app/app/(payments)/checkout/[id]/page.tsx
@@ -15,7 +15,6 @@ interface QueryParams {
 }
 
 const checkoutCurrency = "USD";
-const projectDescriptionDefault = "";
 
 import Image from "next/image";
 import useContract from "@/app/hooks/use-contract";
@@ -93,8 +92,6 @@ const CheckoutPage = ({ params }: { params: { id: string } }) => {
   const [features, isFeaturesLoading] = useFeatures(id);
 
   const checkoutProject = maintainer?.projectName || maintainer?.name;
-  const projectDescription =
-    maintainer?.projectDescription || projectDescriptionDefault;
   const checkoutPrice = isAnnual ? tier?.priceAnnual : tier?.price;
   const checkoutTier = tier?.name;
   const checkoutCadence = isAnnual ? "year" : tier?.cadence;

--- a/components/checkout/prospective-checkout.tsx
+++ b/components/checkout/prospective-checkout.tsx
@@ -6,7 +6,7 @@ import { Bold, Button, Card, TextInput } from "@tremor/react";
 import { addNewProspectForPackage } from "@/app/services/prospect-service";
 import { Tier } from "@prisma/client";
 import { useRouter } from "next/navigation";
-
+import { toast } from "sonner";
 export default function ProspectiveCheckout({ tier }: { tier: Tier }) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const router = useRouter();
@@ -23,7 +23,8 @@ export default function ProspectiveCheckout({ tier }: { tier: Tier }) {
 
     try {
       await addNewProspectForPackage(newProspect, tier);
-      router.push("/success");
+      toast.success("We've received your request. We'll be in touch soon!");
+      router.push("/");
     } catch (error) {
       // TODO(mathusan): handle this error better.
       console.error(error);


### PR DESCRIPTION
Current Behavior:
- Unauthenticated users are redirected to an auth-protected page after contact-us form is filled
- This results in a 404 error shown to the user.

New Behavior:
- On successful contact form submission users are redirect to the root and a toast is shown 
- This means if a customer is doing a contact-form checkout via the Site, then they are redirected to the Site after checkout
- If the customer is doing a doing a contact-form checkout via a checkout link then they are redirected to the GitWallet login page.

Demo:
https://github.com/user-attachments/assets/dee1ac36-c17f-476f-a0a2-df25269d8141

Partially addresses https://github.com/git-wallet/gitwallet-web/issues/445
