### PR TITLE
Platform fees (freemium)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,7 @@ SENDGRID_FROM_NAME="market.dev"
 SENDGRID_FROM_EMAIL="notifications@market.dev"
 
 ## Stripe (Platform)
+PLATFORM_FEE_PERCENT=1.0  # 1% for FREE plan users
 PLATFORM_STRIPE_WEBHOOK_SECRET=whsec_xxx
 
 ## Stripe (Connect)

--- a/app/config/checkout.tsx
+++ b/app/config/checkout.tsx
@@ -1,5 +1,7 @@
-export const GLOBAL_APPLICATION_FEE_DOLLARS = 0;
-export const GLOBAL_APPLICATION_FEE_PCT = 0;
+// Platform fee configuration
+// Default 1% fee for FREE plan organizations
+// Set PLATFORM_FEE_PERCENT in environment to override
+export const DEFAULT_PLATFORM_FEE_PERCENT = 1.0;
 
 export const CHECKOUT_CURRENCY = "USD";
 export const CHECKOUT_CURRENCY_SYMBOL = "$";

--- a/app/services/billing/connect-charge-service.ts
+++ b/app/services/billing/connect-charge-service.ts
@@ -132,7 +132,7 @@ export async function createLocalCharge(
   }
 
   // Calculate platform fee amount for tracking
-  const platformFeeAmount = calculatePlatformFee(
+  const platformFeeAmount = await calculatePlatformFee(
     tier.price || 0,
     vendorOrg.billing?.planType || null
   );

--- a/app/services/billing/connect-checkout-service.ts
+++ b/app/services/billing/connect-checkout-service.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { PlanType } from "@/app/generated/prisma";
 import { createSubscription } from "@/app/services/billing/connect-subscription-service";
 import {
   getCurrentCustomerOrganization,
@@ -100,8 +101,7 @@ export async function processPayment(
       customerOrg.id,
       tierId,
       tier.price,
-      tier.applicationFeePercent || 0,
-      tier.applicationFeePrice || 0
+      vendor.billing?.planType || null
     );
   }
 
@@ -127,8 +127,7 @@ async function processOneTimeCharge(
   customerOrgId: string,
   tierId: string,
   price: number,
-  feePercent: number,
-  feeAmount: number
+  vendorPlanType: PlanType | null
 ): Promise<{ success: boolean; stripeId: string; type: "charge" }> {
   // Get payment method using customer service
   const paymentMethodId = await getStripePaymentMethodIdForVendor(
@@ -146,8 +145,7 @@ async function processOneTimeCharge(
     stripePriceId,
     price,
     paymentMethodId,
-    feePercent,
-    feeAmount
+    vendorPlanType
   );
 
   if (charge.status !== "succeeded") {

--- a/app/services/billing/connect-subscription-service.ts
+++ b/app/services/billing/connect-subscription-service.ts
@@ -124,7 +124,8 @@ export async function createSubscription(
   customerOrgId: string,
   tierId: string,
   stripeSubscriptionId: string,
-  tierVersionId?: string
+  tierVersionId?: string,
+  platformFeeAmount?: number
 ): Promise<Subscription> {
   const customerOrg = await getCustomerOrganizationById(customerOrgId);
   if (!customerOrg) throw new Error("Customer organization not found");
@@ -190,6 +191,7 @@ export async function createSubscription(
       cancelledAt: null,
       activeUntil: null,
       tierRevision: tier.revision,
+      platformFeeAmount: platformFeeAmount || null,
       active: true
     }
   });

--- a/app/services/stripe/stripe-payment-service.ts
+++ b/app/services/stripe/stripe-payment-service.ts
@@ -179,7 +179,7 @@ export async function createStripeCharge(
       payment_method: stripePaymentMethodId,
       off_session: true,
       confirm: true,
-      application_fee_amount: calculatePlatformFee(price, vendorPlanType),
+      application_fee_amount: await calculatePlatformFee(price, vendorPlanType),
       metadata: {
         price_id: stripePriceId // Store the price ID for reference
       }

--- a/app/services/stripe/stripe-price-service.ts
+++ b/app/services/stripe/stripe-price-service.ts
@@ -66,7 +66,10 @@ export async function deactivateStripePrice(
  * @param planType - The vendor organization's plan type
  * @returns The calculated platform fee amount (in cents for Stripe)
  */
-export function calculatePlatformFee(price: number, planType: PlanType | null): number {
+export async function calculatePlatformFee(
+  price: number,
+  planType: PlanType | null
+): Promise<number> {
   // Only apply platform fee for FREE plan organizations
   if (!planType || planType === PlanType.FREE) {
     const feePercent = parseFloat(

--- a/app/services/stripe/stripe-price-service.ts
+++ b/app/services/stripe/stripe-price-service.ts
@@ -1,6 +1,7 @@
 "use server";
 
-import { GLOBAL_APPLICATION_FEE_DOLLARS, GLOBAL_APPLICATION_FEE_PCT } from "@/app/config/checkout";
+import { DEFAULT_PLATFORM_FEE_PERCENT } from "@/app/config/checkout";
+import { PlanType } from "@/app/generated/prisma";
 import Stripe from "stripe";
 import { createStripeClient } from "./create-stripe-client";
 
@@ -59,20 +60,21 @@ export async function deactivateStripePrice(
 }
 
 /**
- * Calculates the application fee amount based on price and fee settings
+ * Calculates the platform fee based on vendor organization's plan type
  *
- * @param price - The base price amount
- * @param applicationFeePercent - Optional percentage fee to apply (added to global fee)
- * @param applicationFeePrice - Optional fixed fee amount to apply (added to global fee)
- * @returns The calculated application fee amount
+ * @param price - The base price amount (in dollars)
+ * @param planType - The vendor organization's plan type
+ * @returns The calculated platform fee amount (in cents for Stripe)
  */
-export async function calculateApplicationFee(
-  price: number,
-  applicationFeePercent: number = 0,
-  applicationFeePrice: number = 0
-): Promise<number> {
-  const totalPercent = (applicationFeePercent + (GLOBAL_APPLICATION_FEE_PCT || 0)) / 100;
-  const totalFee = applicationFeePrice + (GLOBAL_APPLICATION_FEE_DOLLARS || 0);
+export function calculatePlatformFee(price: number, planType: PlanType | null): number {
+  // Only apply platform fee for FREE plan organizations
+  if (!planType || planType === PlanType.FREE) {
+    const feePercent = parseFloat(
+      process.env.PLATFORM_FEE_PERCENT || DEFAULT_PLATFORM_FEE_PERCENT.toString()
+    );
+    return Math.round(price * 100 * (feePercent / 100)); // Convert to cents
+  }
 
-  return Math.round(price * totalPercent) + totalFee;
+  // No platform fee for PRO/CUSTOM plans
+  return 0;
 }

--- a/app/services/tier/tier-service.ts
+++ b/app/services/tier/tier-service.ts
@@ -421,8 +421,6 @@ export async function duplicateTier(tierId: string) {
     stripeProductId: null,
     description: originalTier.description,
     tagline: originalTier.tagline,
-    applicationFeePercent: originalTier.applicationFeePercent,
-    applicationFeePrice: originalTier.applicationFeePrice,
     stripePriceId: null,
     trialDays: originalTier.trialDays,
     priceAnnual: originalTier.priceAnnual,

--- a/prisma/migrations/20250619125505_remove_application_fees_from_tier/migration.sql
+++ b/prisma/migrations/20250619125505_remove_application_fees_from_tier/migration.sql
@@ -1,0 +1,10 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `applicationFeePercent` on the `Tier` table. All the data in the column will be lost.
+  - You are about to drop the column `applicationFeePrice` on the `Tier` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Tier" DROP COLUMN "applicationFeePercent",
+DROP COLUMN "applicationFeePrice";

--- a/prisma/migrations/20250619135313_add_platform_fees_to_charges_and_subs/migration.sql
+++ b/prisma/migrations/20250619135313_add_platform_fees_to_charges_and_subs/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Charge" ADD COLUMN     "platformFeeAmount" INTEGER;
+
+-- AlterTable
+ALTER TABLE "Subscription" ADD COLUMN     "platformFeeAmount" INTEGER;

--- a/prisma/schema/billing.prisma
+++ b/prisma/schema/billing.prisma
@@ -1,15 +1,16 @@
 model Charge {
   id String @id @default(cuid())
 
-  tierRevision   Int?
-  stripeChargeId String       @unique
-  createdAt      DateTime     @default(now())
-  organizationId String
-  organization   Organization @relation(fields: [organizationId], references: [id])
-  tierVersionId  String?
-  tierVersion    TierVersion? @relation(fields: [tierVersionId], references: [id])
-  tierId         String
-  tier           Tier         @relation(fields: [tierId], references: [id])
+  tierRevision      Int?
+  stripeChargeId    String       @unique
+  platformFeeAmount Int? // Platform fee applied (in cents)
+  createdAt         DateTime     @default(now())
+  organizationId    String
+  organization      Organization @relation(fields: [organizationId], references: [id])
+  tierVersionId     String?
+  tierVersion       TierVersion? @relation(fields: [tierVersionId], references: [id])
+  tierId            String
+  tier              Tier         @relation(fields: [tierId], references: [id])
 
   @@index([organizationId, tierId])
 }

--- a/prisma/schema/billing.prisma
+++ b/prisma/schema/billing.prisma
@@ -19,6 +19,7 @@ model Subscription {
   id                   String       @id @default(cuid())
   stripeSubscriptionId String       @unique
   tierRevision         Int?
+  platformFeeAmount    Int? // Platform fee applied to first payment (in cents)
   activeUntil          DateTime?
   cancelledAt          DateTime?
   createdAt            DateTime     @default(now())

--- a/prisma/schema/tier.prisma
+++ b/prisma/schema/tier.prisma
@@ -16,10 +16,8 @@ model Tier {
   organizationId String
   organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
-  price                 Int?
-  applicationFeePercent Int?
-  applicationFeePrice   Int?
-  stripePriceId         String?
+  price         Int?
+  stripePriceId String?
   trialDays             Int     @default(0)
   cadence               String  @default("month")
   priceAnnual           Int?

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -108,8 +108,6 @@ const loadTiers = async (organizations: Organization[]) => {
           createdAt: new Date(),
           updatedAt: new Date(),
           revision: 1,
-          applicationFeePercent: tier.applicationFeePercent || 0,
-          applicationFeePrice: tier.applicationFeePrice || 0,
           trialDays: tier.trialDays || 0,
           cadence: tier.cadence || "month",
           priceAnnual: tier.priceAnnual || null

--- a/prisma/seeds/tiers.yaml
+++ b/prisma/seeds/tiers.yaml
@@ -3,7 +3,6 @@ objects:
     description: "Basic tier with essential features"
     tagline: "Get started with our basic plan"
     price: 1000
-    applicationFeePercent: 10
     trialDays: 14
     cadence: "month"
     priceAnnual: 10000
@@ -11,7 +10,6 @@ objects:
     description: "Professional tier with advanced features"
     tagline: "Unlock the full potential with our pro plan"
     price: 2500
-    applicationFeePercent: 15
     trialDays: 30
     cadence: "month"
     priceAnnual: 25000
@@ -19,7 +17,6 @@ objects:
     description: "Enterprise tier with premium support"
     tagline: "Scale your business with our enterprise plan"
     price: 5000
-    applicationFeePercent: 20
     trialDays: 60
     cadence: "month"
     priceAnnual: 50000
@@ -27,6 +24,5 @@ objects:
     description: "Great way to say thanks"
     tagline: "Perfect for sleepy programmers"
     price: 4
-    applicationFeePercent: 0
     trialDays: 0
     cadence: "once"

--- a/types/organization.ts
+++ b/types/organization.ts
@@ -55,7 +55,7 @@ export type OrganizationForSwitcher = Prisma.OrganizationGetPayload<
 
 /**
  * Prisma validator for organization data needed during checkout and Stripe operations.
- * Includes owner's email, and Stripe JSON fields.
+ * Includes owner's email, Stripe JSON fields, and billing information.
  */
 export const includeOrgForStripeOps = Prisma.validator<Prisma.OrganizationDefaultArgs>()({
   select: {
@@ -71,8 +71,12 @@ export const includeOrgForStripeOps = Prisma.validator<Prisma.OrganizationDefaul
     stripeCustomerIds: true,
     stripePaymentMethodIds: true,
     stripeCSRF: true,
-    // Include other fields if necessary, e.g., stripeAccountId for vendor orgs
-    stripeAccountId: true
+    stripeAccountId: true,
+    billing: {
+      select: {
+        planType: true
+      }
+    }
   }
 });
 


### PR DESCRIPTION
This PR introduces a clean platform fee system to support the freemium business model. Organizations on the **FREE plan** now have a 1% platform fee applied to all customer transactions, while **PRO plan** subscribers enjoy fee-free transactions.

### 🔧 **What's New**
- **Smart fee calculation** based on organization plan type (FREE = 1%, PRO = 0%)
- **Works for both** one-time charges and recurring subscriptions  
- **Database tracking** with new `platformFeeAmount` fields for audit trails
- **Environment configurable** via `PLATFORM_FEE_PERCENT` (defaults to 1.0%)

### 🏗️ **Technical Approach**
- Leverages Stripe's `application_fee_amount` for charges and `application_fee_percent` for subscriptions
- Clean responsibility separation: fee calculation happens in Stripe services, checkout orchestrates the flow
- Simple plan change handling: new transactions use current plan rules, existing subscriptions continue as-is

You don't need to set the "env var" to use the fees, it will default to the 1% without.